### PR TITLE
Update should delete existing code

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -448,7 +448,9 @@ function source_config() {
 	    # if update flag was given, delete the old daemon binary first & proceed
 		if [ "$update" -eq 1 ]; then
 			echo "update given, deleting the old daemon NOW!" &>> ${SCRIPT_LOGFILE}
-			rm -f ${MNODE_DAEMON}
+			rm -f ${MNODE_DAEMON}  	 
+			# remove existing code
+			rm -rf ${SCRIPTPATH}/${CODE_DIR}/${CODENAME}
 		fi
 
 		echo "************************* Installation Plan *****************************************"


### PR DESCRIPTION
The current behaviour of update is confusing in that it deletes the old daemon binary but then proceeds to recompile the binary with the existing code.  In order to update the binary to a newer version, I find myself having to manually delete the code before running the update command.