### PR TITLE
galactrum: version 1.1.6

### DIFF
--- a/config/galactrum/galactrum.env
+++ b/config/galactrum/galactrum.env
@@ -2,5 +2,5 @@ CODENAME=galactrum
 MNODE_DAEMON=${MNODE_DAEMON:-/usr/local/bin/galactrumd}
 MNODE_INBOUND_PORT=${MNODE_INBOUND_PORT:-6270}
 GIT_URL=https://github.com/galactrum/galactrum.git
-SCVERSION="tags/v1.1.4"
+SCVERSION="8c465e0"
 NETWORK_BASE_TAG="2012"


### PR DESCRIPTION
Tag v1.1.6 does not point to the correct commit, so use the commit 8c465e0 directly.