### PR TITLE
Fixed Scorecoin installation

### DIFF
--- a/config/score/score.compile
+++ b/config/score/score.compile
@@ -3,4 +3,4 @@
 cd src && mkdir -p obj/support obj/x11 obj/crypto
 chmod u+x leveldb/build_detect_platform 
 make -f makefile.unix USE_UPNP=-
-cp Scorecoind ${MNODE_DAEMON}
+cp Scored ${MNODE_DAEMON}

--- a/config/score/score.env
+++ b/config/score/score.env
@@ -1,5 +1,5 @@
 CODENAME=score
-MNODE_DAEMON=${MNODE_DAEMON:-/usr/local/bin/scorecoind}
+MNODE_DAEMON=${MNODE_DAEMON:-/usr/local/bin/Scored}
 MNODE_INBOUND_PORT=${MNODE_INBOUND_PORT:-10809}
 GIT_URL=https://github.com/marksteven2017/Scorecoin.git
 SCVERSION="tags/2.0.1"


### PR DESCRIPTION
Changed the Scorecoin damon name from "scrorecoind" to "Scored" in order to fix the broken installation for this coin.