### PR TITLE
Add dixicoin

### DIFF
--- a/config/dxc/dxc.compile
+++ b/config/dxc/dxc.compile
@@ -1,0 +1,9 @@
+#!/bin/bash    
+# this file contains all commands to compile and install the daemon
+chmod u+x share/genbuild.sh
+chmod u+x src/leveldb/build_detect_platform
+chmod u+x ./autogen.sh
+./autogen.sh
+./configure --disable-dependency-tracking --enable-tests=no --without-gui --without-miniupnpc 
+make
+make install

--- a/config/dxc/dxc.conf
+++ b/config/dxc/dxc.conf
@@ -1,0 +1,67 @@
+################################
+# basic settings
+################################
+txindex=1
+logtimestamps=1
+listen=1
+daemon=1
+staking=0
+gen=0
+maxconnections=256
+bind=XXX_IPV6_INT_BASE_XXX:XXX_NETWORK_BASE_TAG_XXX::XXX_NUM_XXY:XXX_MNODE_INBOUND_PORT_XXX
+
+#############################
+# nodes we want to stick to
+#############################
+# addnode=seed1.coinseed.org
+addnode=185.203.116.21:61150
+addnode=149.28.108.129:61150
+addnode=140.82.12.214:61150
+addnode=212.237.34.55:61150
+addnode=209.250.244.76:61150
+addnode=207.148.27.139:61150
+addnode=195.46.187.174:61150
+addnode=207.246.118.184:61150
+addnode=93.171.216.75:61150
+addnode=45.76.62.137:61150
+addnode=51.15.71.140:61150
+addnode=80.240.17.220:61150
+addnode=144.202.106.180:61150
+addnode=8.12.16.13:61150
+addnode=107.191.36.159:61150
+addnode=35.196.55.44:61150
+
+################################
+# masternode specific settings
+################################
+masternode=1
+#### INSERT YOUR MASTERNODE PRIVATEKEY BELOW ####################################################
+masternodeprivkey=HERE_GOES_YOUR_MASTERNODE_KEY_FOR_MASTERNODE_XXX_GIT_PROJECT_XXX_XXX_NUM_XXX
+#################################################################################################
+#
+#                        b.
+#                        88b           Insert your generated masternode privkey here
+#                        888b.
+#                        88888b
+#                        888888b.
+#                        8888P"
+#                        P" `8.
+#                            `8.   
+#                             `8
+#################################################################################################
+
+#############################
+# optional indices
+#############################
+addressindex=1
+timestampindex=1
+spentindex=1
+
+#############################
+# JSONRPC
+#############################
+server=1
+rpcuser=XXX_GIT_PROJECT_XXXrpc
+rpcpassword=XXX_PASS_XXX
+rpcallowip=127.0.0.1
+rpcport=555XXX_NUM_XXX

--- a/config/dxc/dxc.env
+++ b/config/dxc/dxc.env
@@ -1,0 +1,6 @@
+CODENAME=dxc
+MNODE_DAEMON=${MNODE_DAEMON:-/usr/local/bin/dixicoind}
+MNODE_INBOUND_PORT=${MNODE_INBOUND_PORT:-61150}
+GIT_URL=https://github.com/Dixicoin-DXC/Dixicoin.git
+SCVERSION="tags/untagged-9b6fe8bd210320b07944"
+NETWORK_BASE_TAG="2012"


### PR DESCRIPTION
All files necessary to compile DXC (Dixicoin) 
https://dixicoin.net

Project information: 
DixiCoin is developing a trading platform known as DixiHub. Features will include: selling and buying of game keys, loot crates and game time, along with other exciting gaming products in exchange for DixiCoin.

Works with IPv6 as well as IPv4

Install: 4 nodes with IPv6 addressing
```
git clone https://github.com/masternodes/vps.git
cd vps
./install.sh -p dxc-c 4 -n 6
```

